### PR TITLE
Fix failed test cases in my_courses_list test file

### DIFF
--- a/tests/android/pages/android_login.py
+++ b/tests/android/pages/android_login.py
@@ -259,8 +259,10 @@ class AndroidLogin(AndroidBasePage):
         """
 
         self.get_username_editfield().clear()
+        self.get_username_editfield().click()
         self.get_username_editfield().send_keys(user_name)
         self.driver.back()
+        self.get_password_editfield().click()
         self.get_password_editfield().send_keys(password)
         self.driver.back()
         self.get_sign_in_button().click()

--- a/tests/android/pages/android_my_courses_list.py
+++ b/tests/android/pages/android_my_courses_list.py
@@ -122,10 +122,9 @@ class AndroidMyCoursesList(AndroidBasePage):
         """
 
         self.get_find_course_button().click()
-
         return self.global_contents.wait_for_android_activity_to_load(
             self.driver,
-            self.global_contents.WEB_VIEW_FIND_COURSES_ACTIVITY_NAME
+            self.global_contents.MAIN_DASHBOARD_ACTIVITY_NAME
         )
 
     def scroll_course_list_and_click_find_course_button(self):

--- a/tests/android/tests/test_android_my_courses_list.py
+++ b/tests/android/tests/test_android_my_courses_list.py
@@ -76,7 +76,7 @@ class TestAndroidMyCoursesList:
         assert android_main_dashboard_page.get_courses_tab().text == strings.MAIN_DASHBOARD_COURSES_TAB
         assert android_main_dashboard_page.get_discovery_tab().text == strings.MAIN_DASHBOARD_DISCOVERY_TAB
 
-        if android_my_courses_list_page.get_my_courses_list():
+        if android_my_courses_list_page.get_my_courses_list_row():
             assert android_my_courses_list_page.get_my_courses_list_row()
             android_my_courses_list_page.get_contents_from_list()
             android_my_courses_list_page.scroll_course_list_and_click_find_course_button()
@@ -111,8 +111,8 @@ class TestAndroidMyCoursesList:
             global_contents.swipe_screen(set_capabilities)
 
         course_discovery_screen = android_my_courses_list_page.load_discovery_screen()
-        assert course_discovery_screen == global_contents.WEB_VIEW_FIND_COURSES_ACTIVITY_NAME
-        set_capabilities.back()
+        assert course_discovery_screen == global_contents.MAIN_DASHBOARD_ACTIVITY_NAME
+        # set_capabilities.back()
         assert android_main_dashboard_page.on_screen() == global_contents.MAIN_DASHBOARD_ACTIVITY_NAME
 
     def test_landscape_smoke(self, set_capabilities, setup_logging):
@@ -148,14 +148,15 @@ class TestAndroidMyCoursesList:
         global_contents = Globals(setup_logging)
 
         global_contents.turn_orientation(set_capabilities, global_contents.LANDSCAPE_ORIENTATION)
+        android_main_dashboard_page.load_courses_tab()
 
         assert android_main_dashboard_page.get_profile_icon().text == strings.BLANK_FIELD
-        assert android_main_dashboard_page.get_title_textview().text == strings.MAIN_DASHBOARD_SCREEN_TITLE
+        assert android_main_dashboard_page.get_title_textview().text == strings.COURSES_DISCOVERY_COURSES_TAB
         assert android_main_dashboard_page.get_menu_icon().text == strings.BLANK_FIELD
         assert android_main_dashboard_page.get_courses_tab().text == strings.MAIN_DASHBOARD_COURSES_TAB
         assert android_main_dashboard_page.get_discovery_tab().text == strings.MAIN_DASHBOARD_DISCOVERY_TAB
 
-        if android_my_courses_list_page.get_my_courses_list():
+        if android_my_courses_list_page.get_my_courses_list_row():
             assert android_my_courses_list_page.get_my_courses_list_row()
             android_my_courses_list_page.get_contents_from_list()
             course_dashboard_screen = android_my_courses_list_page.load_course_details_screen()
@@ -173,8 +174,8 @@ class TestAndroidMyCoursesList:
         assert find_courses_button == strings.MY_COURSES_LIST_FIND_COURSES_BUTTON_ANDROID
 
         course_discovery_screen = android_my_courses_list_page.load_discovery_screen()
-        assert course_discovery_screen == global_contents.WEB_VIEW_FIND_COURSES_ACTIVITY_NAME
-        set_capabilities.back()
+        assert course_discovery_screen == global_contents.MAIN_DASHBOARD_ACTIVITY_NAME
+        # set_capabilities.back()
         assert android_main_dashboard_page.on_screen() == global_contents.MAIN_DASHBOARD_ACTIVITY_NAME
 
         global_contents.turn_orientation(set_capabilities, global_contents.PORTRAIT_ORIENTATION)


### PR DESCRIPTION
In first test case, open keyboard before send keys to username and password field to press enter button.
In 2nd and 4th test cases update if condition to check 'my_courses_list_row' in case of registered courses are empty.
In 3rd and 4th test cases changed current activity name to fix failed assertions and removed 'set_capabilities.back' method because it closes the application.