### PR TITLE
test android login

### DIFF
--- a/tests/android/pages/android_login.py
+++ b/tests/android/pages/android_login.py
@@ -338,7 +338,11 @@ class AndroidLogin(AndroidBasePage):
         """
 
         self.get_forgot_password_textview().click()
-        return self.driver.find_element_by_id(android_elements.login_reset_password_alert)
+
+        return self.global_contents.wait_and_get_element(
+            self.driver,
+            android_elements.login_reset_password_alert
+        )
 
     def get_forgot_password_alert_title(self):
         """

--- a/tests/android/pages/android_login.py
+++ b/tests/android/pages/android_login.py
@@ -259,8 +259,10 @@ class AndroidLogin(AndroidBasePage):
         """
 
         self.get_username_editfield().clear()
+        self.get_username_editfield().click()
         self.get_username_editfield().send_keys(user_name)
         self.driver.back()
+        self.get_password_editfield().click()
         self.get_password_editfield().send_keys(password)
         self.driver.back()
         self.get_sign_in_button().click()

--- a/tests/common/strings.py
+++ b/tests/common/strings.py
@@ -53,7 +53,7 @@ LOGIN_WRONG_CREDENTIALS_ALERT_MSG = ('Please make sure that your user name or e-
 LOGIN_WRONG_CREDENTIALS_ALERT_OK = 'OK'
 LOGIN_ANDROID_AGREEMENT = ('By signing in to this app, you agree to the edX End User License Agreement and edX Terms '
                            'of Service and Honor Code and you acknowledge that edX and each Member process your '
-                            'personal data in accordance with the Privacy Policy')
+                           'personal data in accordance with the Privacy Policy')
 LOGIN_IOS_AGREEMENT = ('By signing-in to this app, you agree to the edX End User License Agreement and edX Terms '
                        'of Service and Honor Code and acknowledge the Privacy Policy.')
 LOGIN_EULA = 'edX End User License Agreement'

--- a/tests/common/strings.py
+++ b/tests/common/strings.py
@@ -52,7 +52,8 @@ LOGIN_WRONG_CREDENTIALS_ALERT_MSG = ('Please make sure that your user name or e-
                                      ' address and password are correct and try again.')
 LOGIN_WRONG_CREDENTIALS_ALERT_OK = 'OK'
 LOGIN_ANDROID_AGREEMENT = ('By signing in to this app, you agree to the edX End User License Agreement and edX Terms '
-                           'of Service and Honor Code and acknowledge the Privacy Policy')
+                           'of Service and Honor Code and you acknowledge that edX and each Member process your '
+                            'personal data in accordance with the Privacy Policy')
 LOGIN_IOS_AGREEMENT = ('By signing-in to this app, you agree to the edX End User License Agreement and edX Terms '
                        'of Service and Honor Code and acknowledge the Privacy Policy.')
 LOGIN_EULA = 'edX End User License Agreement'


### PR DESCRIPTION
In login page second test case failed, because the login android agreement (Privacy policy) text has been updated, the text we got from edX app was different from the text we have in login_android_agreement variable present in strings file of common folder.
And open keyboard by clicking the field before send keys method in username and password fields.
tested on android 9 and 10.